### PR TITLE
Improve MAVEN build Performance

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -110,14 +110,7 @@
 			<version>3.10.0</version>
 			<scope>test</scope>
 		</dependency>
-		<dependency>
-			<!-- Compatibility: This version of Xerces breaks stuff. The tests must 
-				be able to run with it -->
-			<groupId>xerces</groupId>
-			<artifactId>xercesImpl</artifactId>
-			<scope>test</scope>
-			<version>2.12.0</version>
-		</dependency>
+		
 		<dependency>
 			<groupId>commons-io</groupId>
 			<artifactId>commons-io</artifactId>


### PR DESCRIPTION

[Apache Maven Dependency Plugin](https://maven.apache.org/plugins/maven-dependency-plugin/index.html) can be used to find unused dependencies. And I found following list. Maybe we can remove them.
eaxy
{groupId='xerces', artifactId='xercesImpl'}


=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
